### PR TITLE
zapix/33 dump as signed integers

### DIFF
--- a/mtpylon/crypto/rsa_fingerprint.py
+++ b/mtpylon/crypto/rsa_fingerprint.py
@@ -6,6 +6,7 @@ from rsa import PublicKey  # type: ignore
 
 from mtpylon import long
 from mtpylon.serialization.bytes import dump as dump_bytes
+from mtpylon.serialization.long import load as load_long
 
 
 def get_len_in_bytes(value: int) -> int:
@@ -39,4 +40,4 @@ def get_fingerprint(key: PublicKey) -> long:
     """
     res = num_to_tl_bytes(key.n) + num_to_tl_bytes(key.e)
     h = hashlib.sha1(res)
-    return long(int.from_bytes(h.digest()[-8:], 'little'))
+    return load_long(h.digest()[-8:]).value

--- a/mtpylon/serialization/int.py
+++ b/mtpylon/serialization/int.py
@@ -10,7 +10,7 @@ def dump(value: int) -> bytes:
     Args:
         value - int value that should be dumped
     """
-    return value.to_bytes(4, 'little')
+    return value.to_bytes(4, 'little', signed=True)
 
 
 def load(input: bytes) -> LoadedValue[int]:
@@ -27,4 +27,4 @@ def load(input: bytes) -> LoadedValue[int]:
     """
     if len(input) < 4:
         raise ValueError(f'To load int required 4 bytes. Got {len(input)}')
-    return LoadedValue(int.from_bytes(input[:4], 'little'), 4)
+    return LoadedValue(int.from_bytes(input[:4], 'little', signed=True), 4)

--- a/mtpylon/serialization/long.py
+++ b/mtpylon/serialization/long.py
@@ -11,7 +11,7 @@ def dump(value: long) -> bytes:
     Args:
         value - int value that should be dumped
     """
-    return value.to_bytes(8, 'little')
+    return value.to_bytes(8, 'little', signed=True)
 
 
 def load(input: bytes) -> LoadedValue[long]:
@@ -28,4 +28,7 @@ def load(input: bytes) -> LoadedValue[long]:
     """
     if len(input) < 8:
         raise ValueError(f'To load long required 8 bytes. Got {len(input)}')
-    return LoadedValue(long(int.from_bytes(input[:8], 'little')), 8)
+    return LoadedValue(
+        long(int.from_bytes(input[:8], 'little', signed=True)),
+        8
+    )

--- a/mtpylon/serializers.py
+++ b/mtpylon/serializers.py
@@ -88,9 +88,10 @@ def combinator_to_tl(combinator: CombinatorData) -> str:
     Args:
         combinator - combinator data that should be dumped
     """
+    combinator_id = combinator.id & 0xffffffff
     return '{predicate}#{id} {params}= {type};'.format(**{
         'predicate': combinator.predicate,
-        'id': f'{combinator.id:08x}',
+        'id': f'{combinator_id:08x}',
         'params': params_to_tl(combinator.params),
         'type': combinator.type
     })
@@ -103,9 +104,10 @@ def function_to_tl(func: FunctionData) -> str:
     Args:
         func - function data that should be dumped
     """
+    func_id = func.id & 0xffffffff
     return '{method}#{id} {params}= {type};'.format(**{
         'method': func.method,
-        'id': f'{func.id:08x}',
+        'id': f'{func_id:08x}',
         'params': params_to_tl(func.params),
         'type': func.type
     })

--- a/mtpylon/utils.py
+++ b/mtpylon/utils.py
@@ -30,6 +30,17 @@ from .types import BASIC_TYPES
 PossibleConstructors = Optional[List[Any]]
 
 
+def get_crc32(data: bytes) -> int:
+    """
+    Python binascii.crc32 returns as unsigned int but we need signed int value
+    """
+    return int.from_bytes(
+        binascii.crc32(data).to_bytes(4, 'little'),
+        'little',
+        signed=True
+    )
+
+
 def get_fields_map(class_or_instance: Any) -> Mapping[str, Field]:
     """
     Takes dataclass fields, returns fields map
@@ -447,7 +458,7 @@ def get_combinator_number(combinator: Any, constructor: Any) -> int:
     )
     description_bytes = description.encode()
 
-    return binascii.crc32(description_bytes)
+    return get_crc32(description_bytes)
 
 
 def is_valid_function(
@@ -588,7 +599,7 @@ def get_function_number(func: Callable) -> int:
         function number
     """
     description = build_function_description(func, for_type_number=True)
-    return binascii.crc32(description.encode())
+    return get_crc32(description.encode())
 
 
 def bytes_needed(n: int) -> int:

--- a/tests/simple_manager.py
+++ b/tests/simple_manager.py
@@ -70,7 +70,7 @@ key_data_list = [
         3GL3H2K6/lWGt6y7F1ZUNu8xZBD2J1VftPbdaZQ6fi8jqRlIAok=
         -----END RSA PRIVATE KEY-----
         ''',
-        fingerprint=long(9495775286241702748)
+        fingerprint=long(-8950968787467848868)
     ),
     KeyData(
         public_str='''
@@ -169,7 +169,7 @@ key_data_list = [
         gVetBNHrHzrubLs8GfT2erGwLJ1b31v/XjB1KeiMtThliNe6MCiD
         -----END RSA PRIVATE KEY-----
         ''',
-        fingerprint=long(17442734222710702222)
+        fingerprint=long(-1004009850998849394)
     ),
     KeyData(
         public_str='''
@@ -216,7 +216,7 @@ key_data_list = [
         hIa7d4vHIPPflSd0GRsdJ8bmY0rJjB4qWXiav0xgHA==
         -----END RSA PRIVATE KEY-----
         ''',
-        fingerprint=long(13923728974697425819)
+        fingerprint=long(-4523015099012125797)
     ),
     KeyData(
         public_str='''

--- a/tests/test_crypto/test_rsa_fingerprint.py
+++ b/tests/test_crypto/test_rsa_fingerprint.py
@@ -20,7 +20,7 @@ public_keys_with_fingerprint = [
             -----END RSA PUBLIC KEY-----
             """,
         ),
-        long(0xc3b42b026ce86b21),
+        long(-4344800451088585951),
         id='c3b42b026ce86b21'
     ),
     pytest.param(
@@ -71,7 +71,7 @@ public_keys_with_fingerprint = [
             -----END PUBLIC KEY-----
             """
         ),
-        long(0xaeae98e13cd7f94f),
+        long(-5859577972006586033),
         id="aeae98e13cd7f94f"
     ),
     pytest.param(

--- a/tests/test_messages/test_encrypted_message.py
+++ b/tests/test_messages/test_encrypted_message.py
@@ -32,8 +32,8 @@ auth_key_data = 1917313845044290159121284673148915838663794700370670579369746600
 auth_key_hash = 1394472671087208165269226426108057929670511175639
 auth_key_id = 1435926575080417239
 
-server_salt = long(16009147158398906513)
-session_id = long(11520911270507767959)
+server_salt = long(-2437596915310645103)
+session_id = long(-6925832803201783657)
 
 encrypted_message_bytes = b"\x13\xedo\x9c\xb76'\xd7\xeaU\x0b\xba\xc0\xc4P\xad\x11\xdb\xcaB\x87\xff\xd4\xce\x83\x16\xbfbA\xbf1\xa7\x931\xe8.\x80\xe5\x1d\xb7$=\xc0\x98\x99O\x11\x8a\xb3\xb9P~\x1fb\x007\xab\xa7\x90\xa6\x0f\xa3\xa4\x9c<\xe2\x11u\xb4\xfc\xb6\x8b\x1cR\x96\xb7\xcf&\x01y:\xbf\xc3@\xc2\x9b\xe3E" # noqa
 

--- a/tests/test_messages/test_mtproto_message.py
+++ b/tests/test_messages/test_mtproto_message.py
@@ -29,8 +29,8 @@ auth_key_data = 1917313845044290159121284673148915838663794700370670579369746600
 auth_key_hash = 1394472671087208165269226426108057929670511175639
 auth_key_id = 1435926575080417239
 
-server_salt = long(16009147158398906513)
-session_id = long(11520911270507767959)
+server_salt = long(-2437596915310645103)
+session_id = long(-6925832803201783657)
 
 encrypted_message_bytes = b"\x13\xedo\x9c\xb76'\xd7\xeaU\x0b\xba\xc0\xc4P\xad\x11\xdb\xcaB\x87\xff\xd4\xce\x83\x16\xbfbA\xbf1\xa7\x931\xe8.\x80\xe5\x1d\xb7$=\xc0\x98\x99O\x11\x8a\xb3\xb9P~\x1fb\x007\xab\xa7\x90\xa6\x0f\xa3\xa4\x9c<\xe2\x11u\xb4\xfc\xb6\x8b\x1cR\x96\xb7\xcf&\x01y:\xbf\xc3@\xc2\x9b\xe3E" # noqa
 
@@ -72,7 +72,7 @@ res_pq_message = UnencryptedMessage(
         server_nonce=int128(0x863d23c1bfc0c47e3e59cc4059ea5b35),
         pq=b'\x13\x54\x65\x62\x4e\x61\x25\xfd',
         server_public_key_fingerprints=[
-            long(0xc3b42b026ce86b21),
+            long(-4344800451088585951),
         ],
     ),
 )

--- a/tests/test_messages/test_unencrypted_message.py
+++ b/tests/test_messages/test_unencrypted_message.py
@@ -50,7 +50,7 @@ res_pq_message = UnencryptedMessage(
         server_nonce=int128(0x863d23c1bfc0c47e3e59cc4059ea5b35),
         pq=b'\x13\x54\x65\x62\x4e\x61\x25\xfd',
         server_public_key_fingerprints=[
-            long(0xc3b42b026ce86b21),
+            long(-4344800451088585951),
         ],
     ),
 )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -143,7 +143,7 @@ def test_combinator_number_in_schema():
 
 
 def test_function_number_in_schema():
-    assert 3391236435 in schema
+    assert -903730861 in schema
 
 
 def test_wrong_number():
@@ -153,7 +153,7 @@ def test_wrong_number():
 def test_get_boolTrue_combinator_by_type():  # flake8: noqa
     combinator = schema[BoolTrue]
     assert isinstance(combinator, CombinatorData)
-    assert combinator.id == 2574415285
+    assert combinator.id == -1720552011
     assert len(combinator.params) == 0
     assert combinator.predicate == 'boolTrue'
     assert combinator.type == 'Bool'
@@ -162,25 +162,25 @@ def test_get_boolTrue_combinator_by_type():  # flake8: noqa
 def test_get_task_combinator_by_type():
     combinator = schema[Task]
     assert isinstance(combinator, CombinatorData)
-    assert combinator.id == 0xb801a563
+    assert combinator.id == -1207851677
     assert len(combinator.params) == 5
     assert combinator.predicate == 'task'
     assert combinator.type == 'Task'
 
 
 def test_get_boolTrue_combinator_by_number():  # flake8: noqa
-    combinator = schema[2574415285]
+    combinator = schema[-1720552011]
     assert isinstance(combinator, CombinatorData)
-    assert combinator.id == 2574415285
+    assert combinator.id == -1720552011
     assert len(combinator.params) == 0
     assert combinator.predicate == 'boolTrue'
     assert combinator.type == 'Bool'
 
 
 def test_get_task_combinator_by_number():
-    combinator = schema[0xb801a563]
+    combinator = schema[-1207851677]
     assert isinstance(combinator, CombinatorData)
-    assert combinator.id == 0xb801a563
+    assert combinator.id == -1207851677
     assert len(combinator.params) == 5
     assert combinator.predicate == 'task'
     assert combinator.type == 'Task'

--- a/tests/test_serialization/test_int.py
+++ b/tests/test_serialization/test_int.py
@@ -7,10 +7,21 @@ def test_dump_success():
     assert dump(275) == b'\x13\x01\x00\x00'
 
 
+def test_dump_negative_success():
+    assert dump(-23) == b'\xe9\xff\xff\xff'
+
+
 def test_load_success():
     loaded = load(b'\x13\x01\x00\x00')
 
     assert loaded.value == 275
+    assert loaded.offset == 4
+
+
+def test_load_negative_success():
+    loaded = load(b'\xe9\xff\xff\xff')
+
+    assert loaded.value == -23
     assert loaded.offset == 4
 
 

--- a/tests/test_serialization/test_long.py
+++ b/tests/test_serialization/test_long.py
@@ -7,10 +7,21 @@ def test_dump_success():
     assert dump(275) == b'\x13\x01\x00\x00\x00\x00\x00\x00'
 
 
+def test_dump_negative_success():
+    assert dump(-23) == b'\xe9\xff\xff\xff\xff\xff\xff\xff'
+
+
 def test_load_success():
     loaded = load(b'\x13\x01\x00\x00\x00\x00\x00\x00')
 
     assert loaded.value == 275
+    assert loaded.offset == 8
+
+
+def test_load_negative_success():
+    loaded = load(b'\xe9\xff\xff\xff\xff\xff\xff\xff\xff')
+
+    assert loaded.value == -23
     assert loaded.offset == 8
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -43,13 +43,13 @@ method_names = [
 json_schema = {
     "constructors": [
         {
-            "id": 2574415285,
+            "id": -1720552011,
             "predicate": "boolTrue",
             "type": "Bool",
             "params": []
         },
         {
-            "id": 3162085175,
+            "id": -1132882121,
             "predicate": "boolFalse",
             "type": "Bool",
             "params": []
@@ -88,7 +88,7 @@ json_schema = {
             "params": []
         },
         {
-            "id": 0xb801a563,
+            "id": -1207851677,
             "predicate": "task",
             "type": "Task",
             "params": [
@@ -126,7 +126,7 @@ json_schema = {
             ]
         },
         {
-            "id": 3098825498,
+            "id": -1196141798,
             "predicate": "entity_comment",
             "type": "EntityComment",
             "params": [
@@ -184,13 +184,13 @@ json_schema = {
             ]
         },
         {
-            "id": 3391236435,
+            "id": -903730861,
             "method": "get_task_list",
             "type": "TaskList",
             "params": []
         },
         {
-            "id": 3370625417,
+            "id": -924341879,
             "method": "get_task",
             "type": "Task",
             "params": [

--- a/tests/test_service_schema/test_service_schema.py
+++ b/tests/test_service_schema/test_service_schema.py
@@ -1,14 +1,8 @@
 # -*- coding: utf-8 -*-
-import struct
-
 import pytest
 
 from mtpylon.service_schema.service_schema import service_schema
 from mtpylon.schema import CombinatorData, FunctionData
-
-
-def to_unsigned_int(value: int) -> int:
-    return struct.unpack('<I', struct.pack('<i', value))[0]
 
 
 service_schema_dict = {
@@ -888,7 +882,7 @@ service_schema_dict = {
     ids=lambda x: f"[{x['type']}] {x['predicate']}"
 )
 def test_constructors(service_constructor):
-    constructor_id = to_unsigned_int(service_constructor['id'])
+    constructor_id = service_constructor['id']
     assert constructor_id in service_schema
 
     data = service_schema[constructor_id]
@@ -908,7 +902,7 @@ def test_constructors(service_constructor):
     ids=lambda x: x['method']
 )
 def test_methods(method):
-    method_id = to_unsigned_int(method['id'])
+    method_id = method['id']
 
     assert method_id in service_schema
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -898,18 +898,18 @@ class TestBuildCombinatorDescription:
 class TestCombinatorNumber:
 
     def test_bool(self):
-        assert get_combinator_number(BoolTrue, Bool) == 0x997275b5
-        assert get_combinator_number(BoolFalse, Bool) == 0xbc799737
+        assert get_combinator_number(BoolTrue, Bool) == -1720552011
+        assert get_combinator_number(BoolFalse, Bool) == -1132882121
 
     def test_input_peer(self):
         assertion_list = [
-            (InputPeerEmpty, 0x7f3b18ea),
-            (InputPeerSelf, 0x7da07ec9),
-            (InputPeerChat, 0x179be863),
-            (InputPeerUser, 0x7b8e7de6),
-            (InputPeerChannel, 0x20adaef8),
-            (InputPeerUserFromMessage, 0x17bae2e6),
-            (InputPeerChannelFromMessage, 0x9c95f7bb),
+            (InputPeerEmpty, 2134579434),
+            (InputPeerSelf, 2107670217),
+            (InputPeerChat, 396093539),
+            (InputPeerUser, 2072935910),
+            (InputPeerChannel, 548253432),
+            (InputPeerUserFromMessage, 398123750),
+            (InputPeerChannelFromMessage, -1667893317),
         ]
 
         for combinator, value in assertion_list:
@@ -931,7 +931,7 @@ class TestCombinatorNumber:
         assert get_combinator_number(
             InputMediaPhotoExternal,
             InputMedia
-        ) == 0xe5bbfe1a
+        ) == -440664550
 
     def test_update(self):
         assert get_combinator_number(
@@ -940,7 +940,7 @@ class TestCombinatorNumber:
         ) == 0x26ffde7d
 
     def test_rpc_result(self):
-        assert get_combinator_number(RpcResult, RpcResult) == 0xf35c6d01
+        assert get_combinator_number(RpcResult, RpcResult) == -212046591
 
     def test_msg_container(self):
         assert get_combinator_number(
@@ -974,7 +974,7 @@ class TestBuildFunctionDescription:
 class TestGetFunctionNumber:
 
     def test_equals(self):
-        assert get_function_number(equals) == 0xb5fffb56
+        assert get_function_number(equals) == -1241515178
 
     def test_get_task_content(self):
         assert get_function_number(get_task_content) == 0x2e08ac72


### PR DESCRIPTION
Decided to dump as signed int `int` and `long` values. Coz it's described in documentation: https://core.telegram.org/mtproto/serialize#base-types

Dump as unsigned int `int128`, `int256` cot it hasn't been described in documentation and works good in auth key exchanging, encrypting/decrypting messages. 

- Load dump int as signed int
- Dump/load long with sign

closes #33 